### PR TITLE
Use docker-plugin and stock weave

### DIFF
--- a/.build/.gitignore
+++ b/.build/.gitignore
@@ -1,2 +1,0 @@
-docker
-weave

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 Icon?
 Thumbs.db
 ehthumbs.db
+.build

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ vagrant suspend builder
 ## Compose
 
 ```
+vagrant up tester-1 tester-2 tester-3
 ./local_swarm_manager.sh
 ```
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,24 +2,13 @@
 
 DOCKER_WEAVE_FORK=${DOCKER_WEAVE_FORK:-"https://github.com/squaremo/docker"}
 DOCKER_WEAVE_FORK_BRANCH=${DOCKER_WEAVE_FORK_BRANCH:-"network_extensions"}
+WEAVE_PLUGIN_FORK=${WEAVE_PLUGIN_FORK:-"https://github.com/weaveworks/docker-plugin"}
+WEAVE_PLUGIN_FORK_BRANCH=${WEAVE_PLUGIN_FORK_BRANCH:-"master"}
 
-DOCKER_FLOCKER_FORK=${DOCKER_FLOCKER_FORK:-"https://github.com/calavera/docker"}
-DOCKER_FLOCKER_FORK_BRANCH=${DOCKER_FLOCKER_FORK_BRANCH:-"plugin_discovery"}
-DOCKER_FLOCKER_FORK_REMOTE=${DOCKER_FLOCKER_FORK_REMOTE:-"calavera"}
+if [ -d .build ]; then
+    rm -rf .build
+fi
+git clone --depth 10 --branch=$DOCKER_WEAVE_FORK_BRANCH $DOCKER_WEAVE_FORK .build/docker
+git clone --branch=$WEAVE_PLUGIN_FORK_BRANCH $WEAVE_PLUGIN_FORK .build/docker-plugin
 
-WEAVE_FORK=${WEAVE_FORK:-"https://github.com/squaremo/weave"}
-WEAVE_FORK_BRANCH=${WEAVE_FORK_BRANCH:-"libnetwork_plugin"}
-
-git clone --branch=$DOCKER_WEAVE_FORK_BRANCH $DOCKER_WEAVE_FORK .build/docker
-git clone --branch=$WEAVE_FORK_BRANCH $WEAVE_FORK .build/weave
-
-# rebase the volume extension commits onto the network extension ones
-cd .build/docker
-git remote add $DOCKER_FLOCKER_FORK_REMOTE $DOCKER_FLOCKER_FORK
-git fetch $DOCKER_FLOCKER_FORK_REMOTE $DOCKER_FLOCKER_FORK_BRANCH:$DOCKER_FLOCKER_FORK_BRANCH
-git checkout $DOCKER_FLOCKER_FORK_BRANCH
-git rebase $DOCKER_WEAVE_FORK_BRANCH
-git checkout $DOCKER_WEAVE_FORK_BRANCH
-git merge $DOCKER_FLOCKER_FORK_BRANCH
-cd ../..
 vagrant up builder

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 vagrant ssh builder -c 'export DOCKER_EXPERIMENTAL=1 && make -C src/github.com/docker/docker'
-vagrant ssh builder -c 'make -C src/github.com/weaveworks/weave'
+vagrant ssh builder -c 'make -C src/github.com/weaveworks/docker-plugin'

--- a/tester_scripts.rb
+++ b/tester_scripts.rb
@@ -4,8 +4,10 @@ flocker_prefix = '/var/opt/flocker'
 $install_docker = <<SCRIPT
 #cp /vagrant/.build/docker/bundles/1.7.0-dev/binary/docker-1.7.0-dev /usr/bin/docker
 # this is the docker with DOCKER_EXPERIMENTAL=1
+stop docker
 cp /vagrant/.build/docker/bundles/1.7.0-dev-experimental/binary/docker-1.7.0-dev-experimental /usr/bin/docker
-cp /vagrant/.build/weave/weave /usr/bin/
+sudo curl -L -o /usr/bin/weave https://github.com/weaveworks/weave/releases/download/latest_release/weave
+sudo chmod a+x /usr/bin/weave
 export DEBIAN_FRONTEND=noninteractive
 apt-get -qq update
 apt-get -qq install cgroupfs-mount cgroup-lite xz-utils git
@@ -14,7 +16,7 @@ usermod -a -G docker vagrant
 cp /vagrant/docker.conf /etc/init/
 start docker
 sleep 2
-for i in /vagrant/.build/weave/*.tar
+for i in /vagrant/.build/docker-plugin/*.tar
 do docker load -i $i
 done
 SCRIPT


### PR DESCRIPTION
No need to build weave from scratch; it can be the released
version. The weave plugin does need to be built, though, and how
things are started has changed (specifically, the plugin does not
start weave).

There's also no need to merge a lot of forks of docker, as the
required branches have in general made their way into docker master,
and thence into squaremo/docker/tree/network_extensions.
