### PR TITLE
Change the order that weave things are started

### DIFF
--- a/tester_scripts.rb
+++ b/tester_scripts.rb
@@ -5,6 +5,7 @@ docker_bin = '/vagrant/.build/docker/bundles/1.7.0-dev/binary/docker'
 # /vagrant/.build/docker/bundles/1.7.0-dev-experimental/binary/docker-1.7.0-dev-experimental
 
 $install_docker = <<SCRIPT
+stop docker
 cp #{docker_bin} /usr/bin/docker
 sudo curl --silent --location \
   --output /usr/bin/weave \


### PR DESCRIPTION
- weaveplugin comes last, since it expects the others
- made them idempotent with weave reset and docker rm
- stop docker before trying to replace it
- make weave startup unconditionally succeed, because it frequently
  times out, which halts the provison script
