### PR TITLE
Add a route back to containers from weaveDNS

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -84,6 +84,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           config.vm.provision :shell, :inline => "weave launch -iprange 10.20.0.0/16 #{know_peers.join(' ')} || true"
           config.vm.provision :shell, :inline => "weave launch-dns 10.23.11.#{10+x}/24"
 
+          config.vm.provision :shell, :inline => $weavedns_route
+
           config.vm.provision :shell, :inline => "mkdir -p /etc/flocker"
           config.vm.provision :shell,
           :inline => "echo #{ips[vm_name]} > /etc/flocker/my_address"

--- a/tester_scripts.rb
+++ b/tester_scripts.rb
@@ -24,6 +24,14 @@ do docker load -i $i
 done
 SCRIPT
 
+$weavedns_route = <<SCRIPT
+WEAVEDNS_PID=$(docker inspect --format='{{ .State.Pid }}' weavedns)
+[ ! -d /var/run/netns ] && sudo mkdir -p /var/run/netns
+sudo ln -s /proc/$WEAVEDNS_PID/ns/net /var/run/netns/$WEAVEDNS_PID
+sudo ip netns exec $WEAVEDNS_PID sudo ip route add 10.20.0.0/16 dev ethwe
+sudo rm -f /var/run/netns/$WEAVEDNS_PID
+SCRIPT
+
 $create_flocker_zpool = <<SCRIPT
 mkdir -p #{flocker_prefix}
 truncate --size #{flocker_zpool_size} #{flocker_prefix}/pool-vdev


### PR DESCRIPTION
This is presently required because we are supplying the weave IP
(10.23....) to conainers as the nameserver (i.e., the --dns argument
to docker run). The plugin sets a route in the container to that; this
sets the return route in the weaveDNS container.
