### PR TITLE
Give the same weavedns IP to all containers

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -103,7 +103,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
               -v /proc:/hostproc
             ).join(' '),
             cmd: %W(
-              -nameserver=10.23.11.#{10+x}
+              -nameserver=10.23.11.10
               -debug=true
               -socket=/usr/share/docker/plugins/weave.sock
             ).join(' ')


### PR DESCRIPTION
Since we're routing through the weave bridge, it doesn't matter which
IP we supply as `--dns`. It's sometimes easier to supply the same
address e.g., via swarm, where we don't know where something is
running. All this takes is to give each container a route to the right
place (in fact, it might be even better to give a subnet ...)
